### PR TITLE
User Organisation Access Fix

### DIFF
--- a/commercialoperator/components/organisations/api.py
+++ b/commercialoperator/components/organisations/api.py
@@ -89,9 +89,10 @@ class OrganisationViewSet(viewsets.ModelViewSet):
                 if is_internal(self.request) or self.allow_external:
                         return Organisation.objects.all()
                 elif is_customer(self.request):
-                        org_contacts = OrganisationContact.objects.filter(is_admin=True).filter(email=user.email) #TODO: is there a better way than email?
-                        user_admin_orgs = [org.organisation.id for org in org_contacts]
-                        return Organisation.objects.filter(id__in=user_admin_orgs)
+                        #org_contacts = OrganisationContact.objects.filter(is_admin=True).filter(email=user.email) #TODO: is there a better way than email?
+                        #user_admin_orgs = [org.organisation.id for org in org_contacts]
+                        #return Organisation.objects.filter(id__in=user_admin_orgs)
+                        return user.commercialoperator_organisations.all()
                 return Organisation.objects.none()
 
         @detail_route(methods=['GET',])


### PR DESCRIPTION
Fix that allows all users to access their organisation details via the organisations endpoint, now relying on the serializer to hide pins.

Some functions, such as non-admin users updating address and contact details of the organisation, may warrant further review.