### PR TITLE
Document auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ target/
 
 # media
 media/
+private-media/
 
 # Database/fixture dumps
 *.pgdump

--- a/commercialoperator/components/approvals/api.py
+++ b/commercialoperator/components/approvals/api.py
@@ -271,7 +271,7 @@ class ApprovalViewSet(viewsets.ModelViewSet):
                     _file = request.FILES.get('_file')
 
                 document = instance.qaofficer_documents.get_or_create(input_name=section, name=filename)[0]
-                path = default_storage.save('{}/proposals/{}/approvals/{}'.format(settings.MEDIA_APP_DIR, proposal_id, filename), ContentFile(_file.read()))
+                path = private_storage.save('{}/proposals/{}/approvals/{}'.format(settings.MEDIA_APP_DIR, proposal_id, filename), ContentFile(_file.read()))
 
                 document._file = path
                 document.save()

--- a/commercialoperator/components/approvals/models.py
+++ b/commercialoperator/components/approvals/models.py
@@ -32,6 +32,9 @@ from commercialoperator.components.approvals.email import (
 from commercialoperator.utils import search_keys, search_multiple_keys
 from commercialoperator.helpers import is_customer
 #from commercialoperator.components.approvals.email import send_referral_email_notification
+#TODO: improvable - these three lines are repeated throughout the models and ought to be set in one place
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
 
 
 def update_approval_doc_filename(instance, filename):
@@ -43,7 +46,7 @@ def update_approval_comms_log_filename(instance, filename):
 
 class ApprovalDocument(Document):
     approval = models.ForeignKey('Approval',related_name='documents')
-    _file = models.FileField(upload_to=update_approval_doc_filename, max_length=512)
+    _file = models.FileField(upload_to=update_approval_doc_filename, max_length=512, storage=private_storage)
     can_delete = models.BooleanField(default=True) # after initial submit prevent document from being deleted
 
     def delete(self):
@@ -655,7 +658,7 @@ class ApprovalLogEntry(CommunicationsLogEntry):
 
 class ApprovalLogDocument(Document):
     log_entry = models.ForeignKey('ApprovalLogEntry',related_name='documents', null=True,)
-    _file = models.FileField(upload_to=update_approval_comms_log_filename, null=True, max_length=512)
+    _file = models.FileField(upload_to=update_approval_comms_log_filename, null=True, max_length=512, storage=private_storage)
 
     class Meta:
         app_label = 'commercialoperator'

--- a/commercialoperator/components/compliances/models.py
+++ b/commercialoperator/components/compliances/models.py
@@ -36,6 +36,9 @@ from commercialoperator.components.compliances.email import (
                         )
 from ledger.payments.invoice.models import Invoice
 
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -281,7 +284,7 @@ def update_proposal_complaince_filename(instance, filename):
 
 class ComplianceDocument(Document):
     compliance = models.ForeignKey('Compliance',related_name='documents')
-    _file = models.FileField(upload_to=update_proposal_complaince_filename, max_length=512)
+    _file = models.FileField(upload_to=update_proposal_complaince_filename, max_length=512, storage=private_storage)
     can_delete = models.BooleanField(default=True) # after initial submit prevent document from being deleted
 
     def delete(self):
@@ -338,7 +341,7 @@ def update_compliance_comms_log_filename(instance, filename):
 
 class ComplianceLogDocument(Document):
     log_entry = models.ForeignKey('ComplianceLogEntry',related_name='documents')
-    _file = models.FileField(upload_to=update_compliance_comms_log_filename, max_length=512)
+    _file = models.FileField(upload_to=update_compliance_comms_log_filename, max_length=512, storage=private_storage)
 
     class Meta:
         app_label = 'commercialoperator'

--- a/commercialoperator/components/organisations/models.py
+++ b/commercialoperator/components/organisations/models.py
@@ -27,6 +27,9 @@ from commercialoperator.components.organisations.emails import (
                         send_organisation_request_link_email_notification,
 
             )
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
 
 @python_2_unicode_compatible
 class Organisation(models.Model):
@@ -592,12 +595,12 @@ class OrganisationAction(UserAction):
         app_label = 'commercialoperator'
 
 def update_organisation_comms_log_filename(instance, filename):
-    return 'organisations/{}/communications/{}/{}'.format(instance.log_entry.organisation.id,instance.id,filename)
+    return 'organisations/{}/communications/{}/{}'.format(instance.log_entry.organisation.id,instance.log_entry.id,filename)
 
 
 class OrganisationLogDocument(Document):
     log_entry = models.ForeignKey('OrganisationLogEntry',related_name='documents')
-    _file = models.FileField(upload_to=update_organisation_comms_log_filename, max_length=512)
+    _file = models.FileField(upload_to=update_organisation_comms_log_filename, max_length=512, storage=private_storage)
 
     class Meta:
         app_label = 'commercialoperator'
@@ -630,7 +633,7 @@ class OrganisationRequest(models.Model):
     abn = models.CharField(max_length=50, null=True, blank=True, verbose_name='ABN')
     requester = models.ForeignKey(EmailUser)
     assigned_officer = models.ForeignKey(EmailUser, blank=True, null=True, related_name='org_request_assignee')
-    identification = models.FileField(upload_to='organisation/requests/%Y/%m/%d', max_length=512, null=True, blank=True)
+    identification = models.FileField(upload_to='organisation/requests/%Y/%m/%d', max_length=512, null=True, blank=True, storage=private_storage)
     status = models.CharField(max_length=100,choices=STATUS_CHOICES, default="with_assessor")
     lodgement_date = models.DateTimeField(auto_now_add=True)
     role = models.CharField(max_length=100,choices=ROLE_CHOICES, default="employee")
@@ -785,12 +788,12 @@ class OrganisationRequestDeclinedDetails(models.Model):
         app_label = 'commercialoperator'
 
 def update_organisation_request_comms_log_filename(instance, filename):
-    return 'organisation_requests/{}/communications/{}/{}'.format(instance.log_entry.request.id,instance.id,filename)
+    return 'organisation_requests/{}/communications/{}/{}'.format(instance.log_entry.request.id,instance.log_entry.id,filename)
 
 
 class OrganisationRequestLogDocument(Document):
     log_entry = models.ForeignKey('OrganisationRequestLogEntry',related_name='documents')
-    _file = models.FileField(upload_to=update_organisation_request_comms_log_filename, max_length=512)
+    _file = models.FileField(upload_to=update_organisation_request_comms_log_filename, max_length=512, storage=private_storage)
 
     class Meta:
         app_label = 'commercialoperator'

--- a/commercialoperator/components/proposals/api.py
+++ b/commercialoperator/components/proposals/api.py
@@ -30,6 +30,7 @@ from commercialoperator.components.proposals.utils import save_proponent_data,sa
 from commercialoperator.components.proposals.models import searchKeyWords, search_reference, ProposalUserAction
 from commercialoperator.utils import missing_required_fields
 from commercialoperator.components.main.utils import check_db_connection
+from commercialoperator.components.proposals import models
 
 from django.urls import reverse
 from django.shortcuts import render, redirect, get_object_or_404
@@ -125,7 +126,7 @@ from ledger.payments.invoice.models import Invoice
 
 from commercialoperator.helpers import is_customer, is_internal
 from django.core.files.base import ContentFile
-from django.core.files.storage import default_storage
+#from django.core.files.storage import default_storage
 from rest_framework.pagination import PageNumberPagination, LimitOffsetPagination
 from rest_framework_datatables.pagination import DatatablesPageNumberPagination
 from rest_framework_datatables.filters import DatatablesFilterBackend
@@ -137,6 +138,7 @@ from reversion.models import Version
 import logging
 logger = logging.getLogger(__name__)
 
+private_storage = models.private_storage
 
 class GetProposalType(views.APIView):
     renderer_classes = [JSONRenderer, ]
@@ -758,7 +760,7 @@ class ProposalViewSet(viewsets.ModelViewSet):
                     _file = request.FILES.get('_file')
 
                 document = instance.documents.get_or_create(input_name=section, name=filename)[0]
-                path = default_storage.save('{}/proposals/{}/documents/{}'.format(settings.MEDIA_APP_DIR, proposal_id, filename), ContentFile(_file.read()))
+                path = private_storage.save('{}/proposals/{}/documents/{}'.format(settings.MEDIA_APP_DIR, proposal_id, filename), ContentFile(_file.read()))
 
                 document._file = path
                 document.save()
@@ -818,7 +820,7 @@ class ProposalViewSet(viewsets.ModelViewSet):
                     _file = request.FILES.get('_file')
 
                 document = instance.onhold_documents.get_or_create(input_name=section, name=filename)[0]
-                path = default_storage.save('{}/proposals/{}/onhold/{}'.format(settings.MEDIA_APP_DIR, proposal_id, filename), ContentFile(_file.read()))
+                path = private_storage.save('{}/proposals/{}/onhold/{}'.format(settings.MEDIA_APP_DIR, proposal_id, filename), ContentFile(_file.read()))
 
                 document._file = path
                 document.save()
@@ -866,7 +868,7 @@ class ProposalViewSet(viewsets.ModelViewSet):
                     _file = request.FILES.get('_file')
 
                 document = instance.qaofficer_documents.get_or_create(input_name=section, name=filename)[0]
-                path = default_storage.save('{}/proposals/{}/qaofficer/{}'.format(settings.MEDIA_APP_DIR, proposal_id, filename), ContentFile(_file.read()))
+                path = private_storage.save('{}/proposals/{}/qaofficer/{}'.format(settings.MEDIA_APP_DIR, proposal_id, filename), ContentFile(_file.read()))
 
                 document._file = path
                 document.save()
@@ -1237,7 +1239,7 @@ class ProposalViewSet(viewsets.ModelViewSet):
 
                 required_doc_instance=RequiredDocument.objects.get(id=required_doc_id)
                 document = instance.required_documents.get_or_create(input_name=section, name=filename, required_doc=required_doc_instance)[0]
-                path = default_storage.save('{}/proposals/{}/required_documents/{}'.format(settings.MEDIA_APP_DIR, proposal_id, filename), ContentFile(_file.read()))
+                path = private_storage.save('{}/proposals/{}/required_documents/{}'.format(settings.MEDIA_APP_DIR, proposal_id, filename), ContentFile(_file.read()))
 
                 document._file = path
                 document.save()

--- a/commercialoperator/components/proposals/api_event.py
+++ b/commercialoperator/components/proposals/api_event.py
@@ -55,7 +55,7 @@ from commercialoperator.components.proposals.serializers_event import (
 
 from commercialoperator.helpers import is_customer, is_internal
 from django.core.files.base import ContentFile
-from django.core.files.storage import default_storage
+#from django.core.files.storage import default_storage
 from rest_framework.pagination import PageNumberPagination, LimitOffsetPagination
 from rest_framework_datatables.pagination import DatatablesPageNumberPagination
 from rest_framework_datatables.filters import DatatablesFilterBackend

--- a/commercialoperator/components/proposals/api_filming.py
+++ b/commercialoperator/components/proposals/api_filming.py
@@ -52,7 +52,7 @@ from commercialoperator.components.proposals.serializers_filming import (
 
 from commercialoperator.helpers import is_customer, is_internal
 from django.core.files.base import ContentFile
-from django.core.files.storage import default_storage
+#from django.core.files.storage import default_storage
 from rest_framework.pagination import PageNumberPagination, LimitOffsetPagination
 from rest_framework_datatables.pagination import DatatablesPageNumberPagination
 from rest_framework_datatables.filters import DatatablesFilterBackend

--- a/commercialoperator/components/proposals/email.py
+++ b/commercialoperator/components/proposals/email.py
@@ -4,7 +4,7 @@ from django.core.mail import EmailMultiAlternatives, EmailMessage
 from django.utils.encoding import smart_text
 from django.core.urlresolvers import reverse
 from django.conf import settings
-from django.core.files.storage import default_storage
+#from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
 
 from commercialoperator.components.emails.emails import TemplateEmailBase
@@ -810,7 +810,7 @@ def _log_proposal_email(email_message, proposal, sender=None, file_bytes=None, f
     if file_bytes and filename:
         # attach the file to the comms_log also
         path_to_file = '{}/proposals/{}/communications/{}'.format(settings.MEDIA_APP_DIR, proposal.id, filename)
-        path = default_storage.save(path_to_file, ContentFile(file_bytes))
+        path = private_storage.save(path_to_file, ContentFile(file_bytes))
         email_entry.documents.get_or_create(_file=path_to_file, name=filename)
 
     return email_entry

--- a/commercialoperator/components/proposals/models.py
+++ b/commercialoperator/components/proposals/models.py
@@ -47,7 +47,8 @@ import csv
 import time
 from multiselectfield import MultiSelectField
 
-
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
 
 import logging
 logger = logging.getLogger(__name__)
@@ -247,7 +248,7 @@ class DefaultDocument(Document):
 
 class ProposalDocument(Document):
     proposal = models.ForeignKey('Proposal',related_name='documents')
-    _file = models.FileField(upload_to=update_proposal_doc_filename, max_length=512)
+    _file = models.FileField(upload_to=update_proposal_doc_filename, max_length=512, storage=private_storage)
     input_name = models.CharField(max_length=255,null=True,blank=True)
     can_delete = models.BooleanField(default=True) # after initial submit prevent document from being deleted
     can_hide= models.BooleanField(default=False) # after initial submit, document cannot be deleted but can be hidden
@@ -259,7 +260,7 @@ class ProposalDocument(Document):
 
 class OnHoldDocument(Document):
     proposal = models.ForeignKey('Proposal',related_name='onhold_documents')
-    _file = models.FileField(upload_to=update_onhold_doc_filename, max_length=512)
+    _file = models.FileField(upload_to=update_onhold_doc_filename, max_length=512, storage=private_storage)
     input_name = models.CharField(max_length=255,null=True,blank=True)
     can_delete = models.BooleanField(default=True) # after initial submit prevent document from being deleted
     visible = models.BooleanField(default=True) # to prevent deletion on file system, hidden and still be available in history
@@ -271,7 +272,7 @@ class OnHoldDocument(Document):
 #Documents on Activities(land)and Activities(Marine) tab for T-Class related to required document questions
 class ProposalRequiredDocument(Document):
     proposal = models.ForeignKey('Proposal',related_name='required_documents')
-    _file = models.FileField(upload_to=update_proposal_required_doc_filename, max_length=512)
+    _file = models.FileField(upload_to=update_proposal_required_doc_filename, max_length=512, storage=private_storage)
     input_name = models.CharField(max_length=255,null=True,blank=True)
     can_delete = models.BooleanField(default=True) # after initial submit prevent document from being deleted
     required_doc = models.ForeignKey('RequiredDocument',related_name='proposals')
@@ -288,7 +289,7 @@ class ProposalRequiredDocument(Document):
 
 class QAOfficerDocument(Document):
     proposal = models.ForeignKey('Proposal',related_name='qaofficer_documents')
-    _file = models.FileField(upload_to=update_qaofficer_doc_filename, max_length=512)
+    _file = models.FileField(upload_to=update_qaofficer_doc_filename, max_length=512, storage=private_storage)
     input_name = models.CharField(max_length=255,null=True,blank=True)
     can_delete = models.BooleanField(default=True) # after initial submit prevent document from being deleted
     visible = models.BooleanField(default=True) # to prevent deletion on file system, hidden and still be available in history
@@ -304,7 +305,7 @@ class QAOfficerDocument(Document):
 
 class ReferralDocument(Document):
     referral = models.ForeignKey('Referral',related_name='referral_documents')
-    _file = models.FileField(upload_to=update_referral_doc_filename, max_length=512)
+    _file = models.FileField(upload_to=update_referral_doc_filename, max_length=512, storage=private_storage)
     input_name = models.CharField(max_length=255,null=True,blank=True)
     can_delete = models.BooleanField(default=True) # after initial submit prevent document from being deleted
 
@@ -318,7 +319,7 @@ class ReferralDocument(Document):
 
 class RequirementDocument(Document):
     requirement = models.ForeignKey('ProposalRequirement',related_name='requirement_documents')
-    _file = models.FileField(upload_to=update_requirement_doc_filename, max_length=512)
+    _file = models.FileField(upload_to=update_requirement_doc_filename, max_length=512, storage=private_storage)
     input_name = models.CharField(max_length=255,null=True,blank=True)
     can_delete = models.BooleanField(default=True) # after initial submit prevent document from being deleted
     visible = models.BooleanField(default=True) # to prevent deletion on file system, hidden and still be available in history
@@ -2835,7 +2836,7 @@ class ApplicationFeeDiscount(RevisionedMixin):
 
 class ProposalLogDocument(Document):
     log_entry = models.ForeignKey('ProposalLogEntry',related_name='documents')
-    _file = models.FileField(upload_to=update_proposal_comms_log_filename, max_length=512)
+    _file = models.FileField(upload_to=update_proposal_comms_log_filename, max_length=512, storage=private_storage)
 
     class Meta:
         app_label = 'commercialoperator'
@@ -4960,7 +4961,7 @@ class ProposalFilmingParks(models.Model):
 
 class FilmingParkDocument(Document):
     filming_park = models.ForeignKey('ProposalFilmingParks',related_name='filming_park_documents')
-    _file = models.FileField(upload_to=update_filming_park_doc_filename, max_length=512)
+    _file = models.FileField(upload_to=update_filming_park_doc_filename, max_length=512, storage=private_storage)
     input_name = models.CharField(max_length=255,null=True,blank=True)
     can_delete = models.BooleanField(default=True) # after initial submit prevent document from being deleted
     visible = models.BooleanField(default=True) # to prevent deletion on file system, hidden and still be available in history
@@ -5879,7 +5880,7 @@ class AbseilingClimbingActivity(models.Model):
 
 class EventsParkDocument(Document):
     events_park = models.ForeignKey('ProposalEventsParks',related_name='events_park_documents')
-    _file = models.FileField(upload_to=update_events_park_doc_filename, max_length=512)
+    _file = models.FileField(upload_to=update_events_park_doc_filename, max_length=512, storage=private_storage)
     input_name = models.CharField(max_length=255,null=True,blank=True)
     can_delete = models.BooleanField(default=True) # after initial submit prevent document from being deleted
     visible = models.BooleanField(default=True) # to prevent deletion on file system, hidden and still be available in history
@@ -5928,7 +5929,7 @@ class ProposalPreEventsParks(models.Model):
         return
 class PreEventsParkDocument(Document):
     pre_event_park = models.ForeignKey('ProposalPreEventsParks',related_name='pre_event_park_documents')
-    _file = models.FileField(upload_to=update_pre_event_park_doc_filename, max_length=512)
+    _file = models.FileField(upload_to=update_pre_event_park_doc_filename, max_length=512, storage=private_storage)
     input_name = models.CharField(max_length=255,null=True,blank=True)
     can_delete = models.BooleanField(default=True) # after initial submit prevent document from being deleted
     visible = models.BooleanField(default=True) # to prevent deletion on file system, hidden and still be available in history

--- a/commercialoperator/components/proposals/serializers.py
+++ b/commercialoperator/components/proposals/serializers.py
@@ -435,7 +435,7 @@ class BaseProposalSerializer(serializers.ModelSerializer):
         return None
 
     def get_documents_url(self,obj):
-        return '/media/{}/proposals/{}/documents/'.format(settings.MEDIA_APP_DIR, obj.id)
+        return '/private-media/{}/proposals/{}/documents/'.format(settings.MEDIA_APP_DIR, obj.id)
 
     def get_readonly(self,obj):
         return False

--- a/commercialoperator/components/proposals/serializers_filming.py
+++ b/commercialoperator/components/proposals/serializers_filming.py
@@ -210,7 +210,7 @@ class ProposalFilmingSerializer(serializers.ModelSerializer):
    
 
     def get_documents_url(self,obj):
-        return '/media/{}/proposals/{}/documents/'.format(settings.MEDIA_APP_DIR, obj.id)
+        return '/private-media/{}/proposals/{}/documents/'.format(settings.MEDIA_APP_DIR, obj.id)
 
     def get_readonly(self,obj):
         return False

--- a/commercialoperator/urls.py
+++ b/commercialoperator/urls.py
@@ -196,13 +196,15 @@ urlpatterns = [
     url(r'^history/helppage/(?P<pk>\d+)/$', proposal_views.HelpPageHistoryCompareView.as_view(), name='helppage_history'),
     url(r'^history/organisation/(?P<pk>\d+)/$', organisation_views.OrganisationHistoryCompareView.as_view(), name='organisation_history'),
 
+    url(r'^private-media/', views.getPrivateFile, name='view_private_file'),
 
-] + ledger_patterns + media_serv_patterns
+] + ledger_patterns #+ media_serv_patterns
 
 # if settings.DEBUG:  # Serve media locally in development.
 #     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
-urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if settings.SHOW_DEBUG_TOOLBAR:
     import debug_toolbar


### PR DESCRIPTION
Change to store all uploaded files in /private-media and adds proper authorisation when attempting to access said files. Only internal users or otherwise appropriately authorised external users may access these documents.